### PR TITLE
Rake failed because of two issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'http://rubygems.org'
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,21 @@
+PATH
+  remote: .
+  specs:
+    ipcalc (1.0.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    power_assert (0.2.4)
+    test-unit (3.1.4)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ipcalc!
+  test-unit
+
+BUNDLED WITH
+   1.10.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 Rake::TestTask.new do |t|
   t.libs << 'test'

--- a/ipcalc.gemspec
+++ b/ipcalc.gemspec
@@ -1,12 +1,14 @@
-spec = Gem::Specification.new do |s|
-  s.name                  = 'ipcalc'
-  s.version               = '1.0.0'
-  s.date                  = '2012-04-30'
-  s.summary               = "IP calculation."
-  s.description           = "This gem provides classes that help IP manipulations."
-  s.authors               = ["denis BEURIVE"]
-  s.email                 = 'denis.beurive@gmail.com'
-  s.files                 = ["lib/ipcalc.rb", "lib/ipcalc/Iptools.rb", "lib/ipcalc/Ip.rb"]
-  s.homepage              = 'https://github.com/denis-beurive/ipcalc'
-  s.required_ruby_version = '>= 1.9.1'
+spec = Gem::Specification.new do |spec|
+  spec.name                  = 'ipcalc'
+  spec.version               = '1.0.0'
+  spec.date                  = '2012-04-30'
+  spec.summary               = "IP calculation."
+  spec.description           = "This gem provides classes that help IP manipulations."
+  spec.authors               = ["denis BEURIVE"]
+  spec.email                 = 'denis.beurive@gmail.com'
+  spec.files                 = ["lib/ipcalc.rb", "lib/ipcalc/Iptools.rb", "lib/ipcalc/Ip.rb"]
+  spec.homepage              = 'https://github.com/denis-beurive/ipcalc'
+  spec.required_ruby_version = '>= 1.9.1'
+
+  spec.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
#1 Fixed how to require rdoc.
#2 In Ruby 2.2.0, both Test::Unit and Minitest have been removed from the standard library. Added 'test-unit' as development dependency.
